### PR TITLE
Hotfix: Se corrige reemplazo de tipos de entidades

### DIFF
--- a/frontend/src/modules/workspace/components/project-content/project-tag.tsx
+++ b/frontend/src/modules/workspace/components/project-content/project-tag.tsx
@@ -430,7 +430,7 @@ export class ProjectTagComponent extends React.Component<any> {
 
     const editedTags = tags.map((tag: DatasetItemTag) => {
       delete tag.label;
-      tag.type = documents ? tag.type : 'Document';
+      tag.type = documents ? 'Document' : tag.type;
       return tag;
     });
     const editedWorkout = { ...this.state.workout, tags: editedTags };


### PR DESCRIPTION
## Descripción general

Se detecto que actualmente las entidades que se guardan en base de datos tienen todas el tipo Document, no permitiendo identificar que tipo de entidad es.

### Contexto/Problema

Se debe corregir urgente el bug en frontend para evitar que sigan existiendo entidades malas.

### Solución

Se corrigió una expresion ternaria que estaba invertida y reemplazaba el tipo de tag en todas los trabajos existentes.

## Descripción de QA:

- Se debe clasificar las entidades de un documento y se deben guardar todas las entidades identificadas.
- Se debe identificar cuando el documento fue una separación de documentos.

### Ejercicio y verificación

**Q1:**

- Identificar las entidades de un documento
- Clasificar el documento y enviar solución
- Verificar en la base de datos que la columna tags de la fila correpondiente al documento clasificado **(Tabla: project_dataset_items)** tenga las entidades de forma correcta con sus nombres.

**Q2:**

- Separar un documento
- Clasificar el documento y enviar solución
- Verificar en la base de datos que la columna tags de la fila correpondiente a la separación del documento. Debe marcar un tag por cada documento separado con el tipo 'Document'

