### PR TITLE
Hotfix: bug that prevented item assignations to users

### DIFF
--- a/backend/app/api/versions/v1/projects.rb
+++ b/backend/app/api/versions/v1/projects.rb
@@ -181,21 +181,19 @@ module Versions
                 id = params[:id]
                 tags = params[:tags]
 
-                clasification = ProjectDatasetItem.update(id, {
-                  clasification: params[:clasification],
-                  tags: params[:tags],
-                  status: (params[:status] == -1) ? 2 : 1,
-                  documents: params[:documents]
-                })
+                clasification = ProjectDatasetItem.update(id,
+                                                          clasification: params[:clasification],
+                                                          tags: params[:tags],
+                                                          status: params[:status] == -1 ? 2 : 1,
+                                                          documents: params[:documents])
 
+                # True if "multiples actuaciones"
                 if params[:documents]
-                  dataset = DatasetItem.where({
-                    id: params[:datasetItem][:id]
-                  }).first
+                  dataset = DatasetItem.find_by(id: params[:datasetItem][:id])
                   tags.each do |document|
                     document = dataset[:text][document[:start], document[:end]]
                     # Creamos el dataset
-                    item = DatasetItem.create({
+                    item = DatasetItem.create(
                       raw_text: document,
                       dataset_id: dataset[:dataset_id],
                       name: dataset[:name],
@@ -203,20 +201,20 @@ module Versions
                       metadata: dataset[:metadata],
                       url: dataset[:url],
                       status: dataset[:status]
-                    })
+                    )
                     # Asignamos el nuevo documento al usuario
-                    ProjectDatasetItem.create({
+                    ProjectDatasetItem.create(
                       user_id: params[:user_id],
                       project_id: params[:project_id],
                       clasification: params[:clasification],
                       status: -1,
                       dataset_id: dataset[:dataset_id],
                       dataset_item_id: item.id
-                    })
+                    )
                   end
                 end
 
-                clasification.status = 2;
+                clasification.status = 2
 
                 status 200
                 clasification

--- a/backend/app/models/project_dataset_item.rb
+++ b/backend/app/models/project_dataset_item.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
 class ProjectDatasetItem < ApplicationRecord
   belongs_to :project
   belongs_to :user
   belongs_to :dataset
   belongs_to :dataset_item
+
+  # Statuts meaning
+  # 0  Asignado pero no revisado
+  # 1  asignados
+  # 2  auto asignados
+  # -1  multiple actuacion
 
   def self.create_users_pool(users_pool, project_id)
     free_pool = Project.find(project_id).free_pool.pluck(:id, :dataset_id)
@@ -13,8 +21,8 @@ class ProjectDatasetItem < ApplicationRecord
           user_id: user_id,
           project_id: project_id,
           status: 0,
-          dataset_id: item.dataset,
-          dataset_item_id: item.id
+          dataset_id: item[1],
+          dataset_item_id: item[0]
         )
       end
     end


### PR DESCRIPTION
## Descripción general

### Contexto/Problema
Había un bug que hacía que el backend se caiga al intentar asignar documentos de un dataset a usuarios.

### Solución
Se arregló el bug para que el flujo funcione sin problemas.

## Descripción de QA:

### Precondiciones:

1.  Tener por lo menos un proyecto creado con usuarios y documentos

### Ejercicio

¿Cuáles son los pasos a seguir para hacer el QA?
Ejemplo:
1.  Entrar a [http://localhost:3001/projects](http://localhost:3001/projects).
1. Presionar Asignar, y seleccionar cualquier cantidad de documentos para agregar a un usuario del proyecto.

### Verificación

¿Qué debe pasar luego del paso anterior para verificar el correcto funcionamiento?
1.  Debería completarse la operación sin problemas.
